### PR TITLE
Update evaluation using a rolling average based on similar pawn struc…

### DIFF
--- a/src/eval.h
+++ b/src/eval.h
@@ -20,8 +20,13 @@
 #include <stdlib.h>
 
 #include "types.h"
+#include "util.h"
 
 #define EVAL_UNKNOWN 2046
+
+INLINE int ClampEval(int eval) {
+    return Min(EVAL_UNKNOWN - 1, Max(-EVAL_UNKNOWN + 1, eval));
+}
 
 extern const int PHASE_VALUES[6];
 extern const int MAX_PHASE;

--- a/src/history.c
+++ b/src/history.c
@@ -86,3 +86,10 @@ void UpdateHistories(SearchStack* ss,
     AddHistoryHeuristic(&TH(piece, to, defended, captured), -inc);
   }
 }
+
+void UpdatePawnCorrection(int raw, int real, Board* board, ThreadData* thread) {
+  const int16_t correction = Min(30000, Max(-30000, (real - raw) * PAWN_CORRECTION_GRAIN));
+  const int idx = (board->pawnZobrist & PAWN_CORRECTION_MASK);
+
+  thread->pawnCorrection[idx] = (thread->pawnCorrection[idx] * 255 + correction) / 256;
+}

--- a/src/history.h
+++ b/src/history.h
@@ -76,6 +76,10 @@ INLINE void UpdateCH(SearchStack* ss, Move move, int16_t bonus) {
     AddHistoryHeuristic(&(*(ss - 6)->ch)[Moving(move)][To(move)], bonus);
 }
 
+INLINE int GetPawnCorrection(Board* board, ThreadData* thread) {
+  return thread->pawnCorrection[board->pawnZobrist & PAWN_CORRECTION_MASK] / PAWN_CORRECTION_GRAIN;
+}
+
 void UpdateHistories(SearchStack* ss,
                      ThreadData* thread,
                      Move bestMove,
@@ -84,5 +88,7 @@ void UpdateHistories(SearchStack* ss,
                      int nQ,
                      Move captures[],
                      int nC);
+
+void UpdatePawnCorrection(int raw, int real, Board* board, ThreadData* thread);
 
 #endif

--- a/src/makefile
+++ b/src/makefile
@@ -2,7 +2,7 @@
 EXE      = berserk
 SRC      = *.c nn/*.c pyrrhic/tbprobe.c
 CC       = gcc
-VERSION  = 20240101
+VERSION  = 20240103
 MAIN_NETWORK = berserk-3095fe6f8ce5.nn
 EVALFILE = $(MAIN_NETWORK)
 DEFS     = -DVERSION=\"$(VERSION)\" -DEVALFILE=\"$(EVALFILE)\" -DNDEBUG

--- a/src/types.h
+++ b/src/types.h
@@ -38,6 +38,10 @@
 #define ALIGN_ON 64
 #define ALIGN    __attribute__((aligned(ALIGN_ON)))
 
+#define PAWN_CORRECTION_GRAIN 256
+#define PAWN_CORRECTION_SIZE  16384
+#define PAWN_CORRECTION_MASK  (PAWN_CORRECTION_SIZE - 1)
+
 typedef int Score;
 typedef uint64_t BitBoard;
 typedef uint32_t Move;
@@ -68,6 +72,7 @@ typedef struct {
   int fmr;
   int nullply;
   uint64_t zobrist;
+  uint64_t pawnZobrist;
   BitBoard checkers;
   BitBoard pinned;
   BitBoard threatened;
@@ -94,6 +99,7 @@ typedef struct {
 
   uint64_t piecesCounts; // "material key" - pieces left on the board
   uint64_t zobrist;      // zobrist hash of the position
+  uint64_t pawnZobrist;  // pawn zobrist hash of the position (pawns + stm)
 
   int squares[64];         // piece per square
   BitBoard occupancies[3]; // 0 - white pieces, 1 - black pieces, 2 - both
@@ -187,6 +193,8 @@ struct ThreadData {
   int16_t hh[2][2][2][64 * 64];  // history heuristic butterfly table (stm / threatened)
   int16_t ch[2][12][64][12][64]; // continuation move history table
   int16_t caph[12][64][2][7];    // capture history (piece - to - defeneded - captured_type)
+
+  int16_t pawnCorrection[PAWN_CORRECTION_SIZE];
 
   int action, calls;
   pthread_t nativeThread;

--- a/src/zobrist.c
+++ b/src/zobrist.c
@@ -39,7 +39,7 @@ void InitZobristKeys() {
   ZOBRIST_SIDE_KEY = RandomUInt64();
 }
 
-// Generate a Zobirst key for the current board state
+// Generate a Zobrist key for the current board state
 uint64_t Zobrist(Board* board) {
   uint64_t hash = 0ULL;
 
@@ -53,6 +53,23 @@ uint64_t Zobrist(Board* board) {
     hash ^= ZOBRIST_EP_KEYS[board->epSquare];
 
   hash ^= ZOBRIST_CASTLE_KEYS[board->castling];
+
+  if (board->stm)
+    hash ^= ZOBRIST_SIDE_KEY;
+
+  return hash;
+}
+
+
+// Generate a Pawn Zobrist key for the current board state
+uint64_t PawnZobrist(Board* board) {
+  uint64_t hash = 0ULL;
+
+  for (int piece = WHITE_PAWN; piece <= BLACK_PAWN; piece++) {
+    BitBoard pcs = board->pieces[piece];
+    while (pcs)
+      hash ^= ZOBRIST_PIECES[piece][PopLSB(&pcs)];
+  }
 
   if (board->stm)
     hash ^= ZOBRIST_SIDE_KEY;

--- a/src/zobrist.h
+++ b/src/zobrist.h
@@ -29,6 +29,7 @@ extern uint64_t ZOBRIST_SIDE_KEY;
 
 void InitZobristKeys();
 uint64_t Zobrist(Board* board);
+uint64_t PawnZobrist(Board* board);
 
 INLINE uint64_t KeyAfter(Board* board, const Move move) {
   if (!move)


### PR DESCRIPTION
…tures (#535)

Bench: 2479143

Idea from Caissa

This concept indexes a small table of values which are rolling averages of differences between the static evaluation and the final search result. This correction is then applied @ 50% to the static eval on the next pass.

Elo | 1.02 +- 1.43 (95%)
SPRT | 10.0+0.10s Threads=1 Hash=8MB
LLR | 1.59 (-2.94, 2.94) [0.00, 2.00]
Games | N: 104924 W: 24662 L: 24353 D: 55909
Penta | [627, 12300, 26297, 12613, 625]
http://chess.grantnet.us/test/34924/

Elo | 4.03 +- 3.46 (95%)
SPRT | 60.0+0.60s Threads=1 Hash=64MB
LLR | 2.31 (-2.94, 2.94) [0.00, 2.25]
Games | N: 17050 W: 3865 L: 3667 D: 9518
Penta | [19, 1798, 4691, 2000, 17]
http://chess.grantnet.us/test/34927/